### PR TITLE
Added presumed missing #defines for Brewie model

### DIFF
--- a/ReBrewie/B20.h
+++ b/ReBrewie/B20.h
@@ -1,4 +1,6 @@
 #ifndef B20
+#define B20
+
 // Step Positions
 #define STEP_WATER_INLET  1
 #define STEP_MASH_INLET   2

--- a/ReBrewie/B20Plus.h
+++ b/ReBrewie/B20Plus.h
@@ -1,4 +1,5 @@
 #ifndef B20Plus
+#define B20Plus
 
 // Step Positions
 #define STEP_WATER_INLET  1


### PR DESCRIPTION
I admit, this one is a bit trivial, but without it the ifndef seems out of place. You may also want to to check if the respective variable for the other model was defined to bail out with an error.