### PR TITLE
Debug/Brewmaster fix cooling: Debug cooling enable now requires targe…

### DIFF
--- a/ReBrewie/ReBrewie.ino
+++ b/ReBrewie/ReBrewie.ino
@@ -315,7 +315,9 @@ void Brewie_Command_Decode() {
         boilPump->setPumpSpeed(0);
       } else if (commandNum == 28) {
         brewie->SetCooling();
+        brewie->setTemperatures(-1.0, atof(&brewieData[brewieCommand[1][0]])/10.0);
       } else if (commandNum == 29) {
+        brewie->setTemperatures(-1.0, 0);
         brewie->SetHeating();
       } else if (commandNum == 12) {
         setValve(VALVE_MASH_IN, VALVE_OPEN);
@@ -369,6 +371,7 @@ void Brewie_Command_Decode() {
         brewie->setTemperatures(atof(&brewieData[brewieCommand[1][0]])/10.0, -1.0);
         safetyShutdown = false;
       } else if (commandNum == 51) {
+        brewie->SetHeating();
         brewie->setTemperatures(-1.0, atof(&brewieData[brewieCommand[1][0]])/10.0);
         safetyShutdown = false;
       }


### PR DESCRIPTION
Debug cooling (P128) now requires target temperature. This has been implemented in UI commit 1d7655ae.

This fixes the issue with debug/Brewmaster cooling on the recent ReBrewie firmware, as it now makes use of the same PID controller as heating. Instead of the current workaround by setting the heater to the cooling target temperature before enabling the cooling inlet, the cooling inlet button in UI 1d7655ae now triggers the numpad and appends a temperature to the P128 command.

Note that i haven't tested what would happen if P128 is being sent without the appended temperature, but this was broken already anyway.. :) 
Suggestion: it might be nice to set the temp to the lowest possible value (11c) in case P128 is received without a temperature in order to allow for some backwards compatibility.