### PR TITLE
Implemented the weight sensor for the original B20

### DIFF
--- a/AVR_commands.md
+++ b/AVR_commands.md
@@ -1,0 +1,114 @@
+# Brewie AVR Commands
+
+This document describes the serial protocol implemented by the current
+ReBrewie firmware. Commands are ASCII payloads sent over `/dev/ttyS1` at
+115200 baud, 8N1.
+
+## Serial framing
+
+Host-to-AVR frames use this binary layout:
+
+```text
+$ <sequence> <payload-length> <ASCII payload> <checksum/reserved byte> *
+```
+
+`payload-length` covers only the ASCII payload. Stock B20 firmware expects a
+CRC-8 byte calculated over the payload with polynomial `0x5e`. ReBrewie keeps
+the byte position for compatibility but does not validate it; BrewieNext sends
+ASCII space (`0x20`). Bytes after `*`, including CR/LF, are ignored.
+
+Accepted commands are acknowledged as:
+
+```text
+$ 0x01 <sequence> * CR LF
+```
+
+The AVR also emits tab-separated status records approximately once per second.
+
+## Direct and control commands
+
+| Command | Function | Arguments |
+|---|---|---|
+| `P80` | Initialize calibration and power on | `toLiter toLiterNull mashDelta boilDelta [boilingPoint]` |
+| `P103` | Buffer the next recipe step | 21 numeric fields; see below |
+| `P110` / `P111` | Open / close water inlet | None |
+| `P112` / `P113` | Open / close mash inlet valve | None |
+| `P114` / `P115` | Open / close boil inlet valve | None |
+| `P116` / `P117` | Open / close hop cage 1 | None |
+| `P118` / `P119` | Open / close hop cage 2 | None |
+| `P120` / `P121` | Open / close hop cage 3 | None |
+| `P122` / `P123` | Open / close hop cage 4 | None |
+| `P124` / `P125` | Start / stop mash pump | None; start selects full scale (`255`) |
+| `P126` / `P127` | Start / stop boil pump | None; start selects full scale (`255`) |
+| `P128` | Start automatic cooling to a target | Temperature in tenths of °C, for example `320` for 32.0 °C |
+| `P129` | Stop automatic cooling and return to heating mode | None |
+| `P130` / `P131` | Open / close wort cooling valve | None |
+| `P132` / `P133` | Open / close outlet valve | None |
+| `P134` / `P135` | Open / close mash return valve | None |
+| `P136` / `P137` | Open / close boil return valve | None |
+| `P150` | Set mash-heater target | Temperature in tenths of °C; `0` disables it |
+| `P151` | Set boil-heater target | Temperature in tenths of °C; `0` disables it |
+| `P200` | Start buffered recipe execution | None |
+| `P201` | Pause execution | None; closes valves and disables pumps and heaters |
+| `P202` | Continue execution | None; resumes the current step |
+| `P204` | Request the next step | None |
+| `P205` | Enable / disable developer mode and fast water readings | `1` enables; `0` disables |
+| `P998` | Control drain indicator | `1` on; `0` off |
+| `P999` | Safe reset | No argument; see below |
+
+Targets are parsed as decimal numbers and divided by ten. Consequently,
+`P150 398.2` represents 39.82 °C, although integer tenths are conventional.
+
+## Initialization (`P80`)
+
+`P80` loads the load-cell scale and zero, mash and boil temperature offsets,
+and optional boiling point. A missing boiling point—or one below 86 °C—defaults
+to 100 °C. The command then powers on and initializes the controller.
+
+The legacy Linux application repeatedly sent `P80` until the AVR acknowledged
+initialization. Its values came from `/usr/share/brewie/config.json`.
+
+## Buffered recipe step (`P103`)
+
+The AVR executes one step while retaining one next-step buffer. Sending another
+`P103` while that buffer is occupied reports `E300` and pauses execution.
+
+| Offset | Firmware symbol | Meaning |
+|---:|---|---|
+| 0 | — | Step number, starting at `0` |
+| 1 | `STEP_WATER_INLET` | Water inlet: `0` closed, `1` open |
+| 2 | `STEP_MASH_INLET` | Mash inlet valve |
+| 3 | `STEP_BOIL_INLET` | Boil inlet valve |
+| 4 | `STEP_MASH_TEMP` | Mash target in tenths of °C; `0` disables heating |
+| 5 | `STEP_BOIL_TEMP` | Boil target in tenths of °C; `0` disables heating |
+| 6–9 | `STEP_HOP_1` … `STEP_HOP_4` | Hop-cage valve states |
+| 10 | `STEP_COOL_VALVE` | Wort cooling-valve state |
+| 11 | `STEP_VALVE_11` | Reserved; currently unused |
+| 12 | `STEP_OUTLET` | Outlet-valve state |
+| 13 | `STEP_MASH_PUMP` | Mash-pump command, `0`–`255` |
+| 14 | `STEP_BOIL_PUMP` | Boil-pump command, `0`–`255` |
+| 15 | `STEP_WATER` | Fill quantity in tenths of a liter |
+| 16 | `STEP_TIME` | Step duration in seconds |
+| 17 | `STEP_PRIMARY` | Primary completion mode |
+| 18 | `STEP_SECONDARY` | Secondary behavior mode |
+| 19 | `STEP_MASH_RETURN` | Mash return-valve state |
+| 20 | `STEP_BOIL_RETURN` | Boil return-valve state |
+
+Primary modes currently implemented are: `1` fill to volume, `2` reach mash
+temperature, `3` reach boil temperature, `4` run mash pump until dry, `5` run
+boil pump until dry, `6` run for time, `7` hard boil, `8` final/prompt step,
+and `10` cooling/unclogging.
+
+Secondary modes include `2` sparging/water calibration, `3` hop addition,
+`4` unrestricted water inlet, `5` initial boil fill, `6` sparge fill/timed
+operation, and `8` the final unclogging step. Other values are reserved or not
+fully understood.
+
+## Safe reset (`P999`)
+
+`P999` without arguments closes every valve and both inlets, disables both
+heaters and pumps, clears the active and buffered steps, and resets execution
+timers and state. This is the BrewieNext backend's safe-start command.
+
+The firmware's `P999` path with an argument invokes the broader power-off
+sequence; it should not be used as an ordinary actuator command.

--- a/B20+hardware.md
+++ b/B20+hardware.md
@@ -1,0 +1,119 @@
+# Brewie B20+ hardware reference
+
+This document describes the B20+ profile selected with:
+
+```cpp
+#define BREWIE_HARDWARE_B20 0
+```
+
+The B20+ profile is defined primarily by `ReBrewie/B20Plus.h`. The default
+build currently selects the B20 profile through `HardwareConfig.h`; set the
+flag to `0` only when building for a real B20+ controller.
+
+## Main differences from B20
+
+| Feature | B20+ | B20 |
+|---|---|---|
+| Level measurement | I2C pressure sensor | HX711 load cells |
+| HX711 pins | Not used | PH2/PH7 |
+| Pump outputs | D32/D34 | D2/D5 |
+| Pump tachometers | D2/D3 | Board-specific B20 wiring |
+| Valve power | D13 (`PWR_EN_SERVO`) | PJ2 |
+| Cooling | Automatic cooling controller available | `P128/P129` directly operate cool inlet |
+| Heater outputs | Port-register definitions for the B20+ board | Ordinary digital outputs |
+
+## Power and control signals
+
+Arduino pin numbers are the numbers used by the Arduino APIs. Port names are
+the ATmega2560 electrical names; package pin numbers are included where they
+are useful for probing.
+
+| Symbol | Arduino pin | ATmega2560 signal | Function |
+|---|---:|---|---|
+| `PWR_EN_SERVO` | 13 | PB7, package pin 17 | Servo/valve power enable |
+| `PWR_EN_ARM` | 12 | PB6, package pin 16 | ARM/MCU power enable |
+| `PWR_EN_5V` | 11 | PB5, package pin 15 | 5 V power enable |
+| `PWR_EN_12V` | — | PH7, package pin 27 | 12 V power latch (`PORTH bit 7`) |
+| `PWR_12V_SENSE` | 53 | PB0, package pin 10 | 12 V sense/input |
+| `POWER_BUTTON` | 38 | PD7, package pin 50 | Power button |
+| `DRAIN_BUTTON` | 19 | PD2, package pin 45 | Drain button |
+| `POWER_LIGHT` | 44 | PL5 | Power LED |
+| `DRAIN_LIGHT` | 30 | PC7, package pin 42 | Drain LED |
+
+## Heaters, pumps, and DAC
+
+| Symbol | Arduino pin | ATmega2560 signal | Function |
+|---|---:|---|---|
+| `MASH_HEATER` | 4 | PG5, package pin 56 | Mash heater output |
+| `BOIL_HEATER` | — | PE2, package pin 4 | Boil heater output (`PORTE bit 2`) |
+| `BOIL_PUMP` | 32 | PC5 | Boil pump output (`P126/P127`) |
+| `MASH_PUMP` | 34 | PC3 | Mash pump output (`P124/P125`) |
+| `BOIL_PUMP_TACH` | 2 | PE4, package pin 6 | Boil pump tachometer |
+| `MASH_PUMP_TACH` | 3 | PE5, package pin 7 | Mash pump tachometer |
+| `SPEED_CTRL_MOSI` | 51 | PB2, package pin 12 | Pump-speed DAC SPI data |
+| `SPEED_CTRL_CS` | 10 | PB4, package pin 14 | Pump-speed DAC chip select |
+| `SPEED_CTRL_SCLK` | 52 | PB1, package pin 11 | Pump-speed DAC SPI clock |
+| `SPEED_CTRL_LDAC` | 9 | PH6 | Pump-speed DAC latch |
+
+The pump speed is set through the SPI DAC. `P124/P125` control the mash pump
+and `P126/P127` control the boil pump. Pump-current monitoring uses the
+analog channels listed below, not the B20 A0/A1 wiring.
+
+## Sensors and analog inputs
+
+| Symbol | Arduino input | ATmega2560 signal | Function |
+|---|---:|---|---|
+| `BOIL_TEMP` | 40 | PG1, package pin 52 | Boil-tank DS18B20 bus |
+| `MASH_TEMP` | 41 | PG0, package pin 51 | Mash-tank DS18B20 bus |
+| `AC_MEAS` | `A8` | PK0 / ADC8, package pin 89 | Total AC-current measurement |
+| `BOARD_TEMP` | `A9` | PK1 / ADC9, package pin 88 | Board-temperature input |
+| `I_INLET1` | `A10` | PK2 / ADC10 | Inlet diagnostic/current input |
+| `I_INLET2` | `A11` | PK3 / ADC11 | Inlet diagnostic/current input |
+| `I_VALVES` | `A12` | PK4 / ADC12 | Valve/servo current |
+| `I_BOIL_PUMP` | `A13` | PK5 / ADC13 | Boil pump current |
+| `I_MASH_PUMP` | `A14` | PK6 / ADC14 | Mash pump current |
+
+The pressure sensor is read through the ATmega2560 TWI/I2C peripheral:
+
+```text
+SDA: PD1 / Arduino D20 / package pin 44
+SCL: PD0 / Arduino D21 / package pin 43
+```
+
+The firmware scans for a responding I2C address and uses the discovered
+device for pressure and temperature data. The initial address constant is
+`25` decimal, but the scan result is authoritative.
+
+`E210` belongs to this B20+ AC-current path. Its inherited limits are 20 A
+when `machineVoltage` is not 240 and 12 A when it is 240.
+
+## Inlets, valves, and fans
+
+| Symbol | Arduino pin | ATmega2560 signal | Function |
+|---|---:|---|---|
+| `INLET_1` | 23 | PA1, package pin 23 | Water/cool inlet output |
+| `INLET_2` | 24 | PA2, package pin 24 | Second inlet output |
+| `VENT_FAN` | 22 | PA0, package pin 22 | Ventilation fan |
+| `POWER_FAN` | `A0` | PF0 / ADC0, package pin 97 | Electronics/power fan |
+
+The remaining valve outputs are defined in `Valves.cpp` through the B20+
+port/bit table. B20+ uses its own valve table; do not apply the B20 PJ4/PJ5
+corrections to a B20+ binary.
+
+## Protocol behavior
+
+The standard actuator commands remain compatible with the application:
+
+| Command | Function |
+|---|---|
+| `P124/P125` | Mash pump start/stop |
+| `P126/P127` | Boil pump start/stop |
+| `P128/P129` | B20+ cooling-controller entry/exit behavior |
+| `P150/P151` | Mash/boil heater targets |
+| `P205` | Fan control/override |
+| `P999` | Close all valves |
+
+Unlike B20, the B20+ implementation can use automatic cooling in recipe
+steps and through the cooling controller. The B20 build deliberately
+compiles that behavior out and treats `P128/P129` as direct cool-inlet
+commands.

--- a/B20hardware.md
+++ b/B20hardware.md
@@ -1,0 +1,110 @@
+# Brewie B20 hardware reference
+
+This document describes the hardware selected by `BREWIE_HARDWARE_B20` in
+`ReBrewie/HardwareConfig.h`. The source starts with the B20+ definitions and
+overrides the signals that differ on the original B20 controller.
+
+## Selecting the hardware
+
+```cpp
+#define BREWIE_HARDWARE_B20 1   // original B20
+// #define BREWIE_HARDWARE_B20 0 // B20+
+```
+
+| Build value | Level sensor | Behavior |
+|---|---|---|
+| `1` | HX711 load-cell interface | Original B20 I/O and direct cooling commands |
+| `0` | B20+ I2C pressure sensor | B20+ I/O and automatic cooling behavior |
+
+This is a complete hardware selection, not just a feature switch. A binary
+built for the wrong value can drive the wrong AVR pins and interpret the
+wrong sensors.
+
+## B20 signal map
+
+Arduino pin numbers are the numbers passed to `pinMode()`, `digitalWrite()`,
+and `analogRead()`. The ATmega2560 port name is the electrical reference.
+
+| Symbol | Arduino pin | ATmega2560 signal | Function |
+|---|---:|---|---|
+| `MASH_HEATER` | 13 | PB7 | Mash heater |
+| `BOIL_HEATER` | 4 | PG5 | Boil heater |
+| `BOIL_PUMP` | 2 | PE4 | Logical boil pump (`P126/P127`) |
+| `MASH_PUMP` | 5 | PE3 | Logical mash pump (`P124/P125`) |
+| `INLET_1` | 7 | PH4 | Water-inlet output |
+| `INLET_2` | 6 | PH3, package pin 15 | Cool-inlet output (`P128/P129`) |
+| `POWER_LIGHT` | 41 | PG0, package pin 51 | Power LED |
+| `DRAIN_LIGHT` | 40 | PG1, package pin 52 | Drain LED |
+| `POWER_BUTTON` | 19 | PD2 | AVR-side power-button input |
+| `DRAIN_BUTTON` | 38 | PD7 | AVR-side drain-button input |
+| `VENT_FAN` | 46 | PL3 | Ventilation fan |
+| `POWER_FAN` | 8 | PH5 | Electronics/power fan |
+| `B20_VALVE_POWER_*` | — | PJ2, package pin 65 | Valve-converter enable |
+
+### Sensors and analog inputs
+
+| Symbol | Arduino input | ATmega2560 signal | Function |
+|---|---:|---|---|
+| `MASH_TEMP` | 11 | PB5 | Mash-tank DS18B20 bus |
+| `BOIL_TEMP` | 10 | PB4 | Boil-tank DS18B20 bus |
+| HX711 DOUT | — | PH2, package pin 14 | Load-cell data |
+| HX711 SCK | — | PH7, package pin 27 | Load-cell clock |
+| `I_MASH_PUMP` | `A0` | PF0 / ADC0, package pin 97 | Pump-1/mash current sense |
+| `I_BOIL_PUMP` | `A1` | PF1 / ADC1, package pin 96 | Pump-2/boil current sense |
+| `I_VALVES` | `A4` | PF4 / ADC4, package pin 93 | Valve/servo current sense |
+| `AC_MEAS` | `A8` | PK0 / ADC8, package pin 89 | B20+: total-AC-current input; unused by original B20 |
+| `BOARD_TEMP` | `A9` | PK1 / ADC9, package pin 88 | Current board-temperature input |
+| `I_INLET1` | `A10` | PK2 / ADC10 | Inlet diagnostic input |
+| `I_INLET2` | `A11` | PK3 / ADC11 | Inlet diagnostic input |
+
+The two pump-current values in the status record are emitted as:
+
+```text
+mash/pump-1 diagnostic, mash/pump-1 current,
+boil/pump-2 diagnostic, boil/pump-2 current
+```
+
+These are ADC-derived values, not calibrated amperes. The original B20 hex
+was checked and samples only ADC0/A0 and ADC1/A1 for the pump-current paths;
+it does not use ADC8/PK0. Consequently, the inherited B20+ total-AC-current
+check and `E210` protection are compiled out for B20. B20+ retains the
+original `AC_MEAS` behavior, with limits of 20 A when `machineVoltage` is not
+240 and 12 A when it is 240.
+
+The hardware has also been traced with a chassis DS18B20 on PF2. The current
+source still defines `BOARD_TEMP` as `A9/PK1`; this hardware observation and
+the firmware implementation should be reconciled before treating that path
+as final.
+
+## B20 valve and actuator commands
+
+Valve 9 is unused on the B20 harness. Outlet and cooling are mapped to PJ4
+and PJ5 respectively.
+
+| Command | Function |
+|---|---|
+| `P110/P111` | Water inlet open/close |
+| `P112/P113` | Mash inlet open/close |
+| `P114/P115` | Boil inlet open/close |
+| `P116/P117` through `P122/P123` | Hop cages 1 through 4 |
+| `P124/P125` | Mash pump start/stop |
+| `P126/P127` | Boil pump start/stop |
+| `P128/P129` | Cool inlet open/close |
+| `P130/P131` | Cool valve open/close, PJ5 |
+| `P132/P133` | Outlet valve open/close, PJ4 |
+| `P134/P135` | Mash return open/close |
+| `P136/P137` | Boil return open/close |
+| `P150/P151` | Mash/boil heater targets |
+| `P999` | Close all valves |
+
+## B20 versus B20+
+
+- B20 uses HX711 load cells on PH2/PH7; B20+ uses the pressure-sensor path.
+- B20 uses the B20 pump, valve, inlet, fan, heater, LED, and power mappings
+  above; B20+ retains the definitions in `B20Plus.h`.
+- B20 `P128/P129` directly operate the cooling inlet. Automatic B20+ cooling
+  is disabled for B20.
+- B20 uses PJ2 for valve-converter power instead of the B20+ servo-enable
+  signal.
+- B20 heater outputs are ordinary digital outputs; B20+ uses its differing
+  port-register heater definitions.

--- a/README.md
+++ b/README.md
@@ -1,79 +1,131 @@
-# ReBrewie
+# ReBrewie AVR firmware
+
+Firmware for the ATmega2560 controller used in Brewie brewing systems. The
+firmware controls sensors, heaters, pumps, valves, fans, LEDs, and the serial
+protocol used by the Linux application.
+
+The Linux operating system and graphical application are separate components;
+this repository contains the AVR firmware only.
 
 ## Hardware profiles
 
-The source supports both controller variants through
-`ReBrewie/HardwareConfig.h`:
+The hardware profile is selected in `ReBrewie/HardwareConfig.h`:
 
 ```cpp
-#define BREWIE_HARDWARE_B20 1   // B20: HX711 load cells
-// #define BREWIE_HARDWARE_B20 0 // B20+: I2C pressure sensor
+#define BREWIE_HARDWARE_B20 1   // original B20
+// #define BREWIE_HARDWARE_B20 0 // B20+
 ```
 
-The flag selects the complete controller hardware profile, including sensor
-interfaces, AVR pins, actuators, current channels, and cooling behavior. See
-[B20hardware.md](B20hardware.md) for the detailed B20 pin and command map and
-the differences from B20+.
+This flag selects the complete hardware interface, including pin assignments,
+sensor interfaces, actuator mappings, current channels, and cooling behavior.
+It is not safe to flash a binary built for one controller variant onto the
+other variant.
 
-The corresponding B20+ hardware map is documented in
-[B20+hardware.md](B20+hardware.md).
+Detailed hardware references:
 
-Bring-up diagnostics and automatic power-on are disabled by default. They
-can be enabled temporarily in `ReBrewie.ino` with
-`BREWIE_DIAGNOSTICS` and `BREWIE_AUTO_POWER_ON`.
-Custom, Open-Source firmware for the Brewie B20+ (and maybe B20 eventually)
+- [B20hardware.md](B20hardware.md)
+- [B20+hardware.md](B20+hardware.md)
+- [AVR_commands.md](../AVR_commands.md)
 
-# Intro
-I was planning on releasing this once it was a bit more buttoned-up, but seeing as how I haven't been able to do that I figured why not release it and maybe other 
-people can help, or it can help someone else.
+The current B20 profile uses HX711 load-cell measurement. The B20+ profile
+uses the pressure-sensor interface and retains the B20+ cooling behavior.
 
-This firmware, for the most part, is fully compatible with the original stock Brewie software, but has been improved upon to allow more advanced features that were built into the B20+. Probably for lack of engineering time and for easy of code maintenance, Brewie chose to stick to the B20 firmware and not use the new features because they wouldn't be compatible. 
+Bring-up diagnostics and automatic power-on are disabled by default. They are
+controlled by the `BREWIE_DIAGNOSTICS` and `BREWIE_AUTO_POWER_ON` definitions
+in `ReBrewie.ino`.
 
-# Build instructions
+## Firmware architecture
 
-## Encouragement and Disclaimer
-The Brewie's touch display and wireless communication are controlled by a very small computer that runs Linux as an Operating System. This is why you can login to the machine. The operating system, and consequently all the graphical user interface, are not addressed by this update. Connected to the Linux system is a small chip that is a microcontroller. It receives its own code, i.e. the firmware. The microcontroller then knows how (at what I/O port), e.g., to control valves. The microcontroller also takes action over time, e.g. it knows how steer the heating to keep temperaturs while brewing, and knows how to determine the temperature in the first place, and how to communicate its sensors to the GUI. The order in which the microcontroller executes its activities is determined by the GUI and we call this a "Beer Brewing Recipe". The more expressive or detailed the firmware becomes in the activities it offers, the better the GUI (and us users) can express its culinary desires.
+The firmware communicates with the Linux application over `/dev/ttyS1` at
+115200 baud, 8 data bits, no parity, and 1 stop bit. It receives framed
+commands, maintains the brewing state machine, samples sensors, controls
+actuators, and periodically emits tab-separated status records.
 
-The firmware is built with Arduino. That is a very common platform that you may already have heard about. Kids from 12 years onwards can program that. There are plenty of tutorials out there and small Arduino kits with to learn cost less than grain you put into the Brewie for a brew. One may be tempted to think that one cannot break anything of value while tinkering with this firmware. Wrong. Any stupid error you make (or someone else made in the developer branch) may well ruin your Brewie's hardware or even your home when running unsupervised, e.g. by not closing your valve when letting in the water. Hence, by all means, if you decide to try rebuilding this, do so on your own risk. It also helps to have a more experienced person nearby with whom to share some beers (preferbly after the coding) as an extra pair of eyeballs.
+The main implementation is in `ReBrewie/ReBrewie.ino`; hardware and actuator
+subsystems are implemented in the adjacent `.cpp` and `.h` files.
 
-As already expressed in the MIT License this code is shipping with, do not blame any other developer of this software for time you wasted or any mayhem happening on your end.
+## Build requirements
 
-# Building and Flashing
-The Arduino environment is most easily used via the graphical user interface from your regular Desktop. To retrieve the code of this repository, run
+- Arduino AVR toolchain or Arduino IDE
+- Arduino Mega 2560 board support
+- OneWire library
+- DallasTemperature library
+
+The target is:
+
+```text
+Arduino Mega or Mega 2560
+ATmega2560
 ```
-git clone https://github.com/ronaldombre/ReBrewie
-```
-To install Arduino please google for respective instructions for your Operating System. On Debian or Ubuntu Linux run
-```
-sudo apt update
-sudo apt install arduino
-```
-Then start the environment with
-```
-arduino
-```
-There is a chance that you are requested to connect to a "dialout group" but since the device is not attached to your desktop but to the Brewie, you can ignore that. We will see later how to flash to the Brewie what we are compiling on the Desktop.
 
-When the Arduino interface opens, in the File menu find "Open..." and navigate to the directory you checked out and in the subdirectory ReBrewie find the file ReBrewie.ino. In the "Tools" menu find the item "Board" and select "Arduino Mega or Mega 2560". The item below should then with it change (or manually be changed) to "ATmega 2560". Also in the "Tools" menu, select "Manage Libraries..." and install the "OneWire" and "DallasTemperature" libraries (which provides the respective cognate header files).
+### Arduino IDE
 
-In the "Sketch" menu select "Export Binary", which will compile all source code and yield the files
+Open `ReBrewie/ReBrewie.ino`, select the target above, and use **Sketch →
+Export Compiled Binary**. The application binary will be generated as an
+`.ino.mega.hex` file.
+
+### Command-line build
+
+With Buildroot's Arduino toolchain installed, an example command is:
+
+```sh
+arduino-builder -compile -logger=plain \
+  -hardware /usr/share/arduino/hardware \
+  -tools /usr/share/arduino/tools \
+  -built-in-libraries /usr/share/arduino/hardware/arduino/avr/libraries \
+  -libraries "$HOME/Arduino/libraries" \
+  -fqbn arduino:avr:mega:cpu=atmega2560 \
+  -build-path /tmp/rebrewie-build \
+  ReBrewie/ReBrewie.ino
 ```
-ReBrewie.ino.with_bootloader.mega.hex
-ReBrewie.ino.mega.hex
+
+The resulting file is usually:
+
+```text
+/tmp/rebrewie-build/ReBrewie.ino.hex
 ```
-next to the ReBrewie.ino file.
 
-If at some point you cannot log in to the Brewie, you can connect an in-circuit programmer and use the 6-pin connector to the Brewie PCB. But we happily use the software solution, instead.
+## Flashing through the Brewie Linux system
 
-Follow these steps:
- 1. Make sure you have the Brewie switched on and connected to your local Wifi network. Consider assigning a permanent IP address on your router for the Brewie, so you can address it by name (brewie for me). Otherwise use the IP number, like 192.168.178.57, which will be different in your setup. The gateway will know. Later versions of the GUI will also present the local IP number.
- 2. Copy ReBrewie.ino.mega.hex to the brewie: `scp ReBrewie.ino.mega.hex root@brewie:/tmp/`
- 3. Log in to your brewie: `ssh root@brewie`, the default password is `terminat`
- 3. Kill the GUI, aka the Brewie app: `killall BrewieApplication`.
- 4. Upload the firmware to the microcontroller: `brewie-upload-fw /tmp/ReBrewie.ino.mega.hex` B20+ users will need to run it two or three times to be successful, or modify the upload script.
- 5. Restart the application `BrewieApplication` or `reboot`, just type the respective commands.
+The Linux system communicates with the AVR bootloader through `/dev/ttyS1`.
+The repository's Linux-side upload helper is `brewie-upload-fw`; the exact
+path depends on the Linux image being used.
 
-Caveat: Doing this on a B20+ requires a change in the script so that the reset pin polarity is flipped. There is a define statement for before and after that can be changed.
+Typical workflow:
 
-# Request for Help
-If someone has the time to try to port this over to the B20, that would be amazing. The main thing to figure out would be the pump control, since Brewie used valve controls to slow down the pump for hopping. Maybe PWM or some other sort of valve control would be suitable. The other piece would be the weight sensor, but all that would be required is to figure out where the data is and the rest should fit into the current flow.
+```sh
+scp ReBrewie.ino.hex root@brewie:/tmp/
+ssh root@brewie
+killall BrewieApplication
+brewie-upload-fw /tmp/ReBrewie.ino.hex
+reboot
+```
+
+The uploader resets the AVR and starts `avrdude` with the wiring programmer.
+The reset timing and polarity are hardware-specific; use the B20-specific
+upload helper and configuration supplied with the target Linux image.
+
+An in-circuit programmer connected to the AVR ISP header can be used when the
+serial bootloader is unavailable.
+
+## Protocol
+
+Commands and status fields are documented in [AVR_commands.md](../AVR_commands.md).
+Important actuator commands include:
+
+```text
+P124/P125   mash pump on/off
+P126/P127   boil pump on/off
+P150/P151   mash/boil heater targets
+P999        close all valves
+```
+
+The B20 cooling commands are intentionally different from the B20+ automatic
+cooling behavior; see the hardware references for details.
+
+## Safety
+
+This firmware directly controls mains-powered heaters, pumps, valves, and
+fans. Validate the selected hardware profile, pin map, sensor readings,
+actuator polarity, and fail-safe behavior on the target hardware before
+operating a machine unattended.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # ReBrewie
+
+## Hardware profiles
+
+The source supports both controller variants through
+`ReBrewie/HardwareConfig.h`:
+
+```cpp
+#define BREWIE_HARDWARE_B20 1   // B20: HX711 load cells
+// #define BREWIE_HARDWARE_B20 0 // B20+: I2C pressure sensor
+```
+
+Bring-up diagnostics and automatic power-on are disabled by default. They
+can be enabled temporarily in `ReBrewie.ino` with
+`BREWIE_DIAGNOSTICS` and `BREWIE_AUTO_POWER_ON`.
 Custom, Open-Source firmware for the Brewie B20+ (and maybe B20 eventually)
 
 # Intro
@@ -55,4 +69,3 @@ Caveat: Doing this on a B20+ requires a change in the script so that the reset p
 
 # Request for Help
 If someone has the time to try to port this over to the B20, that would be amazing. The main thing to figure out would be the pump control, since Brewie used valve controls to slow down the pump for hopping. Maybe PWM or some other sort of valve control would be suitable. The other piece would be the weight sensor, but all that would be required is to figure out where the data is and the rest should fit into the current flow.
-

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ The source supports both controller variants through
 // #define BREWIE_HARDWARE_B20 0 // B20+: I2C pressure sensor
 ```
 
+The flag selects the complete controller hardware profile, including sensor
+interfaces, AVR pins, actuators, current channels, and cooling behavior. See
+[B20hardware.md](B20hardware.md) for the detailed B20 pin and command map and
+the differences from B20+.
+
+The corresponding B20+ hardware map is documented in
+[B20+hardware.md](B20+hardware.md).
+
 Bring-up diagnostics and automatic power-on are disabled by default. They
 can be enabled temporarily in `ReBrewie.ino` with
 `BREWIE_DIAGNOSTICS` and `BREWIE_AUTO_POWER_ON`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ uses the pressure-sensor interface and retains the B20+ cooling behavior.
 
 Bring-up diagnostics and automatic power-on are disabled by default. They are
 controlled by the `BREWIE_DIAGNOSTICS` and `BREWIE_AUTO_POWER_ON` definitions
-in `ReBrewie.ino`.
+in `ReBrewie.ino`. `BREWIE_CLOSE_VALVES_ON_BOOT` is enabled by default and
+actively homes every valve to its closed position after an AVR reset. This
+safe startup pass does not power on the controller or enter the AC/E210 path.
 
 ## Firmware architecture
 

--- a/ReBrewie/Brewie.cpp
+++ b/ReBrewie/Brewie.cpp
@@ -1,5 +1,5 @@
 #include "Brewie.h"
-#include "B20Plus.h"
+#include "HardwareConfig.h"
 
 int32_t heaterMinimumCycleTime = 2000;
 

--- a/ReBrewie/Brewie.cpp
+++ b/ReBrewie/Brewie.cpp
@@ -5,7 +5,11 @@ int32_t heaterMinimumCycleTime = 2000;
 
 Brewie::Brewie() {
   MashHeater = new Heater(MASH_HEATER);
+#if BREWIE_HARDWARE_B20
+  BoilHeater = new Heater(BOIL_HEATER);
+#else
   BoilHeater = new Heater(&BOIL_PORT, &BOIL_DIR, BOIL_PIN);
+#endif
   _heaterControlTime = 20000;
   _boilingPoint = 100.0;
   _mashHeaterEnergy = 0.0;
@@ -286,6 +290,7 @@ void Brewie::Temperature_Control() {
     _boilCoolingEnable = false;
   }
   
+#if !BREWIE_HARDWARE_B20
   if (_boilCooling) {
     if (_boilCoolingEnable) {
       digitalWrite(INLET_2, HIGH);
@@ -297,6 +302,7 @@ void Brewie::Temperature_Control() {
       digitalWrite(INLET_2, LOW);
     }
   }
+#endif
 
   // Turn on heaters if permitted
   if (_mashHeatSet) {

--- a/ReBrewie/HX711.cpp
+++ b/ReBrewie/HX711.cpp
@@ -1,0 +1,160 @@
+/*
+ * HX711 Arduino driver, adapted from bogde/HX711.
+ * Original project: https://github.com/bogde/HX711
+ * MIT License, Copyright (c) 2018 Bogdan Necula.
+ */
+#include "HX711.h"
+
+HX711::HX711()
+    : _pd_sck(0), _dout(0), _gain(1), _offset(0), _scale(1.0f),
+      _port_h(false), _dout_mask(0), _sck_mask(0) {}
+
+void HX711::begin(byte dout, byte pd_sck, byte gain) {
+    _port_h = false;
+    _dout = dout;
+    _pd_sck = pd_sck;
+    pinMode(_pd_sck, OUTPUT);
+    digitalWrite(_pd_sck, LOW);
+    pinMode(_dout, INPUT_PULLUP);
+    set_gain(gain);
+}
+
+void HX711::begin_port_h(byte dout_bit, byte pd_sck_bit, byte gain) {
+    _port_h = true;
+    _dout_mask = (byte)(1U << dout_bit);
+    _sck_mask = (byte)(1U << pd_sck_bit);
+    configure_port_h();
+    set_gain(gain);
+}
+
+inline void HX711::configure_port_h() {
+    DDRH &= (byte)~_dout_mask;
+    PORTH |= _dout_mask;       // input pull-up on DOUT
+    DDRH |= _sck_mask;
+    PORTH &= (byte)~_sck_mask; // SCK must idle low
+}
+
+inline bool HX711::read_dout() {
+    return _port_h ? ((PINH & _dout_mask) != 0) : (digitalRead(_dout) != LOW);
+}
+
+inline void HX711::write_sck(bool high) {
+    if (_port_h) {
+        if (high) {
+            PORTH |= _sck_mask;
+        } else {
+            PORTH &= (byte)~_sck_mask;
+        }
+    } else {
+        digitalWrite(_pd_sck, high ? HIGH : LOW);
+    }
+}
+
+bool HX711::is_ready() {
+    return !read_dout();
+}
+
+void HX711::wait_ready(unsigned long delay_ms) {
+    while (!is_ready()) {
+        delay(delay_ms);
+    }
+}
+
+bool HX711::wait_ready_timeout(unsigned long timeout, unsigned long delay_ms) {
+    unsigned long started = millis();
+    while (millis() - started < timeout) {
+        if (is_ready()) {
+            return true;
+        }
+        delay(delay_ms);
+    }
+    return false;
+}
+
+void HX711::set_gain(byte gain) {
+    switch (gain) {
+    case 128: _gain = 1; break; // channel A, gain 128
+    case 64:  _gain = 3; break; // channel A, gain 64
+    case 32:  _gain = 2; break; // channel B, gain 32
+    default:  _gain = 1; break;
+    }
+}
+
+byte HX711::shift_byte() {
+    byte value = 0;
+    for (byte bit = 0; bit < 8; ++bit) {
+        write_sck(true);
+        delayMicroseconds(1);
+        value = (byte)(value << 1);
+        if (read_dout()) {
+            value |= 1;
+        }
+        write_sck(false);
+        delayMicroseconds(1);
+    }
+    return value;
+}
+
+long HX711::read() {
+    wait_ready();
+
+    noInterrupts();
+    byte data[3];
+    data[2] = shift_byte();
+    data[1] = shift_byte();
+    data[0] = shift_byte();
+
+    // Select channel and gain for the next conversion.
+    for (byte i = 0; i < _gain; ++i) {
+        write_sck(true);
+        delayMicroseconds(1);
+        write_sck(false);
+        delayMicroseconds(1);
+    }
+    interrupts();
+
+    byte filler = (data[2] & 0x80) ? 0xFF : 0x00;
+    uint32_t value = ((uint32_t)filler << 24) |
+                     ((uint32_t)data[2] << 16) |
+                     ((uint32_t)data[1] << 8) |
+                     data[0];
+    return (long)value;
+}
+
+long HX711::read_average(byte times) {
+    if (times == 0) {
+        return 0;
+    }
+    int64_t sum = 0;
+    for (byte i = 0; i < times; ++i) {
+        sum += read();
+        delay(0);
+    }
+    return (long)(sum / times);
+}
+
+double HX711::get_value(byte times) {
+    return (double)read_average(times) - _offset;
+}
+
+float HX711::get_units(byte times) {
+    return (float)(get_value(times) / _scale);
+}
+
+void HX711::tare(byte times) {
+    set_offset(read_average(times));
+}
+
+void HX711::set_scale(float scale) { _scale = scale; }
+float HX711::get_scale() { return _scale; }
+void HX711::set_offset(long offset) { _offset = offset; }
+long HX711::get_offset() { return _offset; }
+
+void HX711::power_down() {
+    write_sck(false);
+    write_sck(true);
+}
+
+void HX711::power_up() {
+    write_sck(false);
+}

--- a/ReBrewie/HX711.h
+++ b/ReBrewie/HX711.h
@@ -1,0 +1,55 @@
+/*
+ * HX711 Arduino driver, adapted from bogde/HX711.
+ * Original project: https://github.com/bogde/HX711
+ * MIT License, Copyright (c) 2018 Bogdan Necula.
+ *
+ * The B20 uses the ATmega2560 port-H pins directly, so this adaptation adds
+ * begin_port_h() for DOUT=PH2 and SCK=PH7 while retaining the small public
+ * API used by the original Arduino library.
+ */
+#ifndef BREWIE_HX711_H
+#define BREWIE_HX711_H
+
+#include <Arduino.h>
+
+class HX711 {
+public:
+    HX711();
+
+    void begin(byte dout, byte pd_sck, byte gain = 128);
+    void begin_port_h(byte dout_bit, byte pd_sck_bit, byte gain = 128);
+
+    bool is_ready();
+    void wait_ready(unsigned long delay_ms = 0);
+    bool wait_ready_timeout(unsigned long timeout = 1000,
+                            unsigned long delay_ms = 0);
+    void set_gain(byte gain = 128);
+    long read();
+    long read_average(byte times = 10);
+    double get_value(byte times = 1);
+    float get_units(byte times = 1);
+    void tare(byte times = 10);
+    void set_scale(float scale = 1.0f);
+    float get_scale();
+    void set_offset(long offset = 0);
+    long get_offset();
+    void power_down();
+    void power_up();
+
+private:
+    byte _pd_sck;
+    byte _dout;
+    byte _gain;
+    long _offset;
+    float _scale;
+    bool _port_h;
+    byte _dout_mask;
+    byte _sck_mask;
+
+    inline bool read_dout();
+    inline void write_sck(bool high);
+    inline void configure_port_h();
+    byte shift_byte();
+};
+
+#endif

--- a/ReBrewie/HardwareConfig.h
+++ b/ReBrewie/HardwareConfig.h
@@ -15,6 +15,56 @@
 
 #if BREWIE_HARDWARE_B20
   #define BREWIE_USE_HX711 1
+
+  #undef MASH_HEATER
+  #define MASH_HEATER 13
+  #undef BOIL_HEATER
+  #define BOIL_HEATER 4
+
+  // Original B20 controller I/O. B20Plus.h supplies the shared power and
+  // heater definitions; these signals differ on the two board revisions.
+  #undef LED1
+  #define LED1 41
+  #undef LED2
+  #define LED2 40
+  // PG0, ATmega2560 package pin 51, Arduino Mega digital pin 41.
+  #undef POWER_LIGHT
+  #define POWER_LIGHT 41
+  #undef DRAIN_LIGHT
+  #define DRAIN_LIGHT 40
+  // The B20 wiring has the physical power button on AVR pin 19 and the
+  // drain button on AVR pin 38.  B20Plus.h uses the opposite legacy map.
+  #undef POWER_BUTTON
+  #define POWER_BUTTON 19
+  #undef DRAIN_BUTTON
+  #define DRAIN_BUTTON 38
+  // PJ2, ATmega2560 package pin 65.  PJ2 has no Arduino Mega digital-pin
+  // alias in the standard variant; use direct PORTJ access.
+  #define B20_VALVE_POWER_PORT PORTJ
+  #define B20_VALVE_POWER_DDR DDRJ
+  #define B20_VALVE_POWER_BIT PJ2
+  #undef BOIL_PUMP
+  #define BOIL_PUMP 2
+  #undef MASH_PUMP
+  #define MASH_PUMP 5
+  // B20 LMV324 current-sense outputs. On the B20 controller wiring, PF0/A0
+  // is the mash/pump-1 sense channel and PF1/A1 is the boil/pump-2 sense
+  // channel. PF4/A4 is the servo/valve current channel.
+  #undef I_BOIL_PUMP
+  #define I_BOIL_PUMP A1
+  #undef I_MASH_PUMP
+  #define I_MASH_PUMP A0
+  #undef I_VALVES
+  #define I_VALVES A4
+  #undef INLET_1
+  #define INLET_1 7
+  #undef INLET_2
+  #define INLET_2 6
+  #undef VENT_FAN
+  #define VENT_FAN 46
+  #undef POWER_FAN
+  #define POWER_FAN 8
+
   #undef MASH_TEMP
   #define MASH_TEMP 11
   #undef BOIL_TEMP

--- a/ReBrewie/HardwareConfig.h
+++ b/ReBrewie/HardwareConfig.h
@@ -1,0 +1,26 @@
+/*
+ * Brewie AVR hardware selection.
+ *
+ * Select the physical controller board here.  The B20 uses the HX711 load
+ * cell interface and the B20+ uses the original I2C pressure sensor.
+ */
+#ifndef BREWIE_HARDWARE_CONFIG_H
+#define BREWIE_HARDWARE_CONFIG_H
+
+#ifndef BREWIE_HARDWARE_B20
+#define BREWIE_HARDWARE_B20 1
+#endif
+
+#include "B20Plus.h"
+
+#if BREWIE_HARDWARE_B20
+  #define BREWIE_USE_HX711 1
+  #undef MASH_TEMP
+  #define MASH_TEMP 11
+  #undef BOIL_TEMP
+  #define BOIL_TEMP 10
+#else
+  #define BREWIE_USE_HX711 0
+#endif
+
+#endif

--- a/ReBrewie/Pump.cpp
+++ b/ReBrewie/Pump.cpp
@@ -180,7 +180,7 @@ void Pump::setPumpSpeed(uint8_t pumpSpeed) {
     _pumpDiag = 0;
     _pumpEnable = false;
     _pumpOut = false;
-    //digitalWrite(_pumpPin, LOW);
+    digitalWrite(_pumpPin, LOW);
   } else {
     _running = true;
     _pumpDiag = 255;
@@ -203,7 +203,7 @@ void Pump::_setPumpSpeed() {
     _running = false;
     _pumpDiag = 0;
     _pumpEnable = false;
-    //digitalWrite(_pumpPin, LOW);
+    digitalWrite(_pumpPin, LOW);
   } else {
     _running = true;
     _pumpDiag = 255;
@@ -222,6 +222,7 @@ void Pump::_stopPump() {
   _pumpDry = false;
   _running = false;
   _pumpDiag = 0;
+  digitalWrite(_pumpPin, LOW);
 }
 
 void Pump::writeDAC() {

--- a/ReBrewie/Pump.cpp
+++ b/ReBrewie/Pump.cpp
@@ -184,7 +184,6 @@ void Pump::setPumpSpeed(uint8_t pumpSpeed) {
   } else {
     _running = true;
     _pumpDiag = 255;
-    PORTH |= 0x80;
     digitalWrite(_pumpPin, HIGH);
     _pumpEnable = true;
     _pumpSpeedRestart = _pumpSpeed;
@@ -208,7 +207,6 @@ void Pump::_setPumpSpeed() {
   } else {
     _running = true;
     _pumpDiag = 255;
-    PORTH |= 0x80;
     digitalWrite(_pumpPin, HIGH);
     _pumpEnable = true;
   }

--- a/ReBrewie/ReBrewie.ino
+++ b/ReBrewie/ReBrewie.ino
@@ -8,10 +8,24 @@
 #include "Valves.h"
 #include "Pressure.h"
 #include "Notifications.h"
+#include "HX711.h"
 
 // Brewie Version setup
-#include "B20Plus.h"
-//#include "B20.h"
+#include "HardwareConfig.h"
+
+// Human-readable hardware diagnostics for bring-up.  Set to 0 for the
+// production firmware; diagnostics are deliberately not part of the normal
+// tab-separated status protocol.
+#ifndef BREWIE_DIAGNOSTICS
+#define BREWIE_DIAGNOSTICS 0
+#endif
+
+// Bring-up convenience: initialize the AVR power/sensor state at boot
+// without waiting for the host's P80 calibration command.  Set to 0 for
+// production, where the host protocol controls power-on.
+#ifndef BREWIE_AUTO_POWER_ON
+#define BREWIE_AUTO_POWER_ON 0
+#endif
 
 // Global Configurations
 uint8_t spargePumpSpeed = 100;      // Reduce sparging pumping speed
@@ -74,10 +88,10 @@ DeviceAddress chassisAddress;
 #endif
 
 // Sensor Variables
-uint8_t massAddress = 25;             // Default for my machine
-uint16_t massSensor = 0;
-int16_t massFast = 0;
-int16_t massOffset = 0;
+uint8_t massAddress = 25;             // B20+ pressure sensor address
+int32_t massSensor = 0;
+int32_t massFast = 0;
+int32_t massOffset = 0;
 bool validMass = false;
 float waterVolume = 0;
 uint16_t massTemp = 0;
@@ -116,12 +130,102 @@ volatile bool drainButton = false;
 Brewie* brewie;
 Pump* mashPump;
 Pump* boilPump;
+HX711 weightScale;
+
+#if BREWIE_DIAGNOSTICS
+void Diagnostics_Report() {
+  static uint32_t lastReport;
+  if (millis() - lastReport < 2000) {
+    return;
+  }
+  lastReport = millis();
+
+  Serial.println("!--- Brewie hardware diagnostics ---");
+  Serial.print("!powerOn=");
+  Serial.print(powerOn ? 1 : 0);
+  Serial.print(" powerButton(pin ");
+  Serial.print(POWER_BUTTON);
+  Serial.print(")=");
+  Serial.print(digitalRead(POWER_BUTTON));
+  Serial.print(" drainButton(pin ");
+  Serial.print(DRAIN_BUTTON);
+  Serial.print(")=");
+  Serial.println(digitalRead(DRAIN_BUTTON));
+
+  Serial.print("!temp mash pin=");
+  Serial.print(MASH_TEMP);
+  Serial.print(" devices=");
+  Serial.print(MashTemp ? MashTemp->getDeviceCount() : 0);
+  Serial.print(" value=");
+  Serial.print(mashTemp, 2);
+  Serial.print(" address=");
+  for (uint8_t i = 0; i < 8; i++) {
+    if (mashAddress[i] < 16) Serial.print('0');
+    Serial.print(mashAddress[i], HEX);
+  }
+  Serial.println();
+
+  Serial.print("!temp boil pin=");
+  Serial.print(BOIL_TEMP);
+  Serial.print(" devices=");
+  Serial.print(BoilTemp ? BoilTemp->getDeviceCount() : 0);
+  Serial.print(" value=");
+  Serial.print(boilTemp, 2);
+  Serial.print(" address=");
+  if (BoilTemp && BoilTemp->getDeviceCount() > 0) {
+    for (uint8_t i = 0; i < 8; i++) {
+      if (boilAddress[i] < 16) Serial.print('0');
+      Serial.print(boilAddress[i], HEX);
+    }
+  } else {
+    Serial.print("none");
+  }
+  Serial.println();
+
+  Serial.print("!hx711 DOUT=PH2/14 level=");
+  Serial.print((PINH & _BV(PH2)) ? 1 : 0);
+  Serial.print(" SCK=PH7/27 level=");
+  Serial.print((PINH & _BV(PH7)) ? 1 : 0);
+  Serial.print(" raw=");
+  Serial.print((long)massFast);
+  Serial.print(" valid=");
+  Serial.print(validMass ? 1 : 0);
+  Serial.print(" reported=");
+  Serial.print((long)massSensor);
+  Serial.print(" volume=");
+  Serial.println(waterVolume, 4);
+
+  Serial.print("!calibration toLiter=");
+  Serial.print(toLiter, 4);
+  Serial.print(" null=");
+  Serial.print(toLiterNull, 4);
+  Serial.print(" mashDelta=");
+  Serial.print(mashDelta, 4);
+  Serial.print(" boilDelta=");
+  Serial.println(boilDelta, 4);
+
+  Serial.print("!adc boardTemp=");
+  Serial.print(boardTemp, 2);
+  Serial.print(" inlet1=");
+  Serial.print(inlet1A, 2);
+  Serial.print(" inlet2=");
+  Serial.print(inlet2A, 2);
+  Serial.print(" boilPump=");
+  Serial.print(boilPumpA, 2);
+  Serial.print(" mashPump=");
+  Serial.println(mashPumpA, 2);
+  Serial.println("!------------------------------------");
+}
+#endif
 
 void setup() {
   Initialize_2560();
 }
 
 void loop() {
+#if BREWIE_DIAGNOSTICS
+  Diagnostics_Report();
+#endif
   if (powerOn) {
     Process_Sensors();
     brewie->Temperature_Control();
@@ -245,7 +349,7 @@ void Brewie_Status_Write() {
     }
   }
   brewieLength += sprintf(&statusMessage[brewieLength], "V%d\t", mcuVersion);
-  brewieLength += sprintf(&statusMessage[brewieLength], "%u\t", (uint16_t)massSensor);
+  brewieLength += sprintf(&statusMessage[brewieLength], "%ld\t", (long)massSensor);
   brewieLength += floatToStringAppend(&waterVolume, &statusMessage[brewieLength]);
   float floatTemp = mashTemp - mashDelta;
   brewieLength += floatToStringAppend(&floatTemp, &statusMessage[brewieLength]);
@@ -806,7 +910,7 @@ void Process_Sensors() {
   static uint32_t sensorTime = millis();
   static uint32_t sensorArray[5] = { 0, 0, 0, 0, 0 };
   static uint16_t samples = 0;
-  static uint32_t massAve = 0;
+  static int64_t massAve = 0;
   static uint8_t massSamp = 0;
   static uint32_t massTime = millis();
   static uint32_t peakTempLast = 0; 
@@ -933,12 +1037,27 @@ void Process_Sensors() {
     Serial.println("!Power brownout imminent!");
   }*/
 
-  // Pressure sensor seems to take > 100ms to take a reading
-  // Process I2C Weight/Pressure Sensors
+  // The B20 HX711 produces one signed 24-bit sample at approximately 10 SPS.
+  // Do not block the main control loop waiting for a disconnected sensor.
+#if BREWIE_USE_HX711
+  if (weightScale.wait_ready_timeout(1)) {
+    massFast = weightScale.read();
+    validMass = true;
+    massOffset = 0;
+    if (boilPump->pumpTach() < 5 && !boilPump->isRunning()) {
+      massAve += massFast;
+      massSamp++;
+    }
+  }
+#else
+  // B20+ pressure sensor seems to take >100ms to take a reading.
+  // Process I2C Weight/Pressure Sensors.
   if (millis() - massTime > 44) {
     massTime = millis();
 
-    uint8_t errorCode = PressureReadAll(&massFast, &massTemp, massAddress);
+    int16_t pressureRaw = 0;
+    uint8_t errorCode = PressureReadAll(&pressureRaw, &massTemp, massAddress);
+    massFast = pressureRaw;
     if (errorCode != 0) {
       massSensor = errorCode;
       TWIInit();
@@ -976,16 +1095,16 @@ void Process_Sensors() {
     }
 
     if (massSamp > 7) {
-      massSensor = (uint16_t)((float)massAve/(float)massSamp);
+      massSensor = (int32_t)(massAve/(int64_t)massSamp);
       if (fastWaterReadings) {
-        int16_t adjMass = (int16_t)massSensor - (int16_t)toLiterNull;
+        int32_t adjMass = massSensor - (int32_t)toLiterNull;
         if (adjMass < 0) {
           adjMass = 0;
         }
         waterVolume = (float)adjMass/toLiter;
       } else {
-        if (massSensor > ((uint16_t)toLiterNull)) {
-          massSensor -= (uint16_t)toLiterNull;
+        if (massSensor > (int32_t)toLiterNull) {
+          massSensor -= (int32_t)toLiterNull;
         } else {
           massSensor = 0;
         }
@@ -995,6 +1114,29 @@ void Process_Sensors() {
       massSamp = 0;
     }
   }
+#endif
+
+#if BREWIE_USE_HX711
+  if (massSamp > 7) {
+    massSensor = (int32_t)(massAve / (int64_t)massSamp);
+    if (fastWaterReadings) {
+      int32_t adjMass = massSensor - (int32_t)toLiterNull;
+      if (adjMass < 0) {
+        adjMass = 0;
+      }
+      waterVolume = (float)adjMass / toLiter;
+    } else {
+      if (massSensor > (int32_t)toLiterNull) {
+        massSensor -= (int32_t)toLiterNull;
+      } else {
+        massSensor = 0;
+      }
+      waterVolume = (float)massSensor / toLiter;
+    }
+    massAve = 0;
+    massSamp = 0;
+  }
+#endif
 }
 
 void Run_Sparge() {
@@ -1809,11 +1951,33 @@ void Initialize_2560() {
 
   TWIInit();
 
+#if BREWIE_USE_HX711
+  // B20: HX711 DOUT is PH2 (package pin 14), clock is PH7 (package pin 27).
+  // Use channel A, gain 128, matching the bogde/HX711 default.
+  weightScale.begin_port_h(2, 7, 128);
+#endif
+
   attachInterrupt(digitalPinToInterrupt(BOIL_PUMP_TACH), boilTachISR, FALLING);
   attachInterrupt(digitalPinToInterrupt(MASH_PUMP_TACH), mashTachISR, FALLING);
 
   MashTempPin = new OneWire(MASH_TEMP);
   BoilTempPin = new OneWire(BOIL_TEMP);
+
+  // Construct and initialize the DallasTemperature interfaces before the
+  // first Process_Temperature() call.  The original source only created
+  // these objects later in the error-recovery path, leaving the normal path
+  // with null pointers and no usable temperature readings.
+  MashTemp = new DallasTemperature(MashTempPin);
+  MashTemp->begin();
+  MashTemp->getAddress(mashAddress, 0);
+  MashTemp->setCheckForConversion(true);
+  MashTemp->setWaitForConversion(false);
+
+  BoilTemp = new DallasTemperature(BoilTempPin);
+  BoilTemp->begin();
+  BoilTemp->getAddress(boilAddress, 0);
+  BoilTemp->setCheckForConversion(true);
+  BoilTemp->setWaitForConversion(false);
 
   statusTime = millis();
 
@@ -1834,6 +1998,10 @@ void Initialize_2560() {
   //PORTJ = 0;
   DDRE |= 0x02;
   PORTE &= ~0x02;
+
+#if BREWIE_AUTO_POWER_ON
+  Power_On();
+#endif
 }
 
 void Close_All_Valves() {
@@ -1880,7 +2048,8 @@ void Brewie_Reset() {
 void Power_On() {
   digitalWrite(POWER_LIGHT, HIGH);
   if (!powerOn) {
-    PORTH |= 0x80;
+    // PH7 is reserved for the B20 HX711 clock; do not use the B20+ 12 V
+    // enable operation here.
     Brewie_Reset();
     delay(200);
     digitalWrite(PWR_EN_5V, HIGH);
@@ -1893,16 +2062,18 @@ void Power_On() {
     TIMSK5 |= _BV(TOIE5) + _BV(OCIE5C);
     DDRE &= ~0x02;
 
+#if !BREWIE_USE_HX711
     Serial.print("!Scanning I2C...");
     uint8_t iAddress = ScanTWI();
     Serial.println("done");
     if (iAddress > 1 && iAddress < 128) {
-      //massAddress = iAddress; 
+      //massAddress = iAddress;
       Serial.print("!Pressure sensor found at address: 0x");
       Serial.println(iAddress, HEX);
     } else {
       Serial.println("!Pressure sensor not found!");
     }
+#endif
   }
 }
 
@@ -1921,7 +2092,7 @@ void Power_Off() {
   digitalWrite(VENT_FAN, LOW);
   digitalWrite(POWER_FAN, LOW);
   digitalWrite(PWR_EN_SERVO, LOW);
-  PORTH &= ~0x80;
+  // PH7 is reserved for the B20 HX711 clock.
   digitalWrite(PWR_EN_ARM, LOW);
   digitalWrite(PWR_EN_5V, LOW);
   digitalWrite(POWER_LIGHT, LOW);

--- a/ReBrewie/ReBrewie.ino
+++ b/ReBrewie/ReBrewie.ino
@@ -418,11 +418,21 @@ void Brewie_Command_Decode() {
       } else if (commandNum == 27) {
         boilPump->setPumpSpeed(0);
       } else if (commandNum == 28) {
+#if BREWIE_HARDWARE_B20
+        // Original B20 protocol: direct cool-inlet actuator command.
+        digitalWrite(INLET_2, HIGH);
+#else
+        // B20+ behavior: P128 enters the automatic cooling controller.
         brewie->SetCooling();
         brewie->setTemperatures(-1.0, atof(&brewieData[brewieCommand[1][0]])/10.0);
+#endif
       } else if (commandNum == 29) {
+#if BREWIE_HARDWARE_B20
+        digitalWrite(INLET_2, LOW);
+#else
         brewie->setTemperatures(-1.0, 0);
         brewie->SetHeating();
+#endif
       } else if (commandNum == 12) {
         setValve(VALVE_MASH_IN, VALVE_OPEN);
       } else if (commandNum == 13) {
@@ -528,6 +538,16 @@ void Brewie_Command_Decode() {
           brewing = false;
           fastWaterReadings = false;
         }
+      }
+    } else if (brewieData[3] == '7') {
+      if (brewieData[4] == '9') {        // Reset water-level zero point (P79)
+        // The legacy application sends P79 without arguments. Use the
+        // current signed HX711 reading as the empty-tank reference so the
+        // calculated volume becomes zero without altering the raw report.
+#if BREWIE_USE_HX711
+        toLiterNull = (float)massSensor;
+        waterVolume = 0.0;
+#endif
       }
     } else if (brewieData[3] == '8') {
       // Load calibration constants to MCU
@@ -697,7 +717,9 @@ void Process_Step() {
     case 9: // Might not exist
       break;
     case 10: // Cool Step/Unclogging step
+#if !BREWIE_HARDWARE_B20
       brewie->SetCooling();
+#endif
       break;
     default: 
       break;
@@ -1119,20 +1141,12 @@ void Process_Sensors() {
 #if BREWIE_USE_HX711
   if (massSamp > 7) {
     massSensor = (int32_t)(massAve / (int64_t)massSamp);
-    if (fastWaterReadings) {
-      int32_t adjMass = massSensor - (int32_t)toLiterNull;
-      if (adjMass < 0) {
-        adjMass = 0;
-      }
-      waterVolume = (float)adjMass / toLiter;
-    } else {
-      if (massSensor > (int32_t)toLiterNull) {
-        massSensor -= (int32_t)toLiterNull;
-      } else {
-        massSensor = 0;
-      }
-      waterVolume = (float)massSensor / toLiter;
-    }
+    // The original B20 firmware reports the signed HX711 reading in the
+    // status frame, including a negative empty-tank value.  Apply the null
+    // point only to the calculated volume; do not clamp or modify massSensor.
+    // This reproduces, for example, -288253 / 18996.1 = -15.174326 liters.
+    int32_t adjMass = massSensor - (int32_t)toLiterNull;
+    waterVolume = (float)adjMass / toLiter;
     massAve = 0;
     massSamp = 0;
   }
@@ -1576,7 +1590,7 @@ void Safety_Check() {
         digitalWrite(DRAIN_LIGHT, LOW);
       }
     } else {
-      digitalWrite(POWER_LIGHT, LOW);
+      digitalWrite(POWER_LIGHT, powerOn ? HIGH : LOW);
       digitalWrite(DRAIN_LIGHT, LOW);
     }
   } else {
@@ -1912,6 +1926,19 @@ void Initialize_2560() {
   pinMode(LED1, OUTPUT);
   pinMode(INLET_1, OUTPUT);
   pinMode(INLET_2, OUTPUT);
+  // Explicitly clear the output latches after the board-wide pull-up setup;
+  // pinMode(OUTPUT) otherwise preserves a previously latched high state.
+  digitalWrite(VENT_FAN, LOW);
+  digitalWrite(POWER_FAN, LOW);
+  digitalWrite(INLET_1, LOW);
+  digitalWrite(INLET_2, LOW);
+#if BREWIE_HARDWARE_B20
+  // B20 valve outputs use PJ0/PJ1 and PJ4/PJ5; PJ2 is the converter enable.
+  // The generic unused-pin setup leaves these pins as inputs, so explicitly
+  // claim all of them here and clear their output latches.
+  DDRJ |= 0x37;
+  PORTJ &= (uint8_t)~0x37;
+#endif
 
   // SPI for DAC
   pinMode(SPEED_CTRL_SCLK, OUTPUT);
@@ -1923,8 +1950,13 @@ void Initialize_2560() {
   pinMode(50, INPUT);   //MISO, DAC doesn't send any data though
   pinMode(53, OUTPUT);  //Main ~CS, needs to be output for SPI to work
 
+#if BREWIE_HARDWARE_B20
+  B20_VALVE_POWER_DDR |= _BV(B20_VALVE_POWER_BIT);
+  B20_VALVE_POWER_PORT &= (uint8_t)~_BV(B20_VALVE_POWER_BIT);
+#else
   pinMode(PWR_EN_SERVO, OUTPUT);
   digitalWrite(PWR_EN_SERVO, LOW);
+#endif
   
   // Power Enable 12V
   //DDRH |= 0x80;
@@ -1953,8 +1985,9 @@ void Initialize_2560() {
 
 #if BREWIE_USE_HX711
   // B20: HX711 DOUT is PH2 (package pin 14), clock is PH7 (package pin 27).
-  // Use channel A, gain 128, matching the bogde/HX711 default.
-  weightScale.begin_port_h(2, 7, 128);
+  // The original B20 calibration factor is consistent with channel A,
+  // gain 64.  Gain 128 produces approximately twice the counts per liter.
+  weightScale.begin_port_h(2, 7, 64);
 #endif
 
   attachInterrupt(digitalPinToInterrupt(BOIL_PUMP_TACH), boilTachISR, FALLING);
@@ -2058,6 +2091,13 @@ void Power_On() {
     digitalWrite(PWR_EN_ARM, HIGH);
     delay(500);
     Close_All_Valves();
+    // Development test: keep the suspected B20 valve-converter enable on so
+    // it can be measured after startup and while testing individual valves.
+#if BREWIE_HARDWARE_B20
+    B20_VALVE_POWER_PORT |= _BV(B20_VALVE_POWER_BIT);
+#else
+    digitalWrite(PWR_EN_SERVO, HIGH);
+#endif
     powerOn = true;
     TIMSK5 |= _BV(TOIE5) + _BV(OCIE5C);
     DDRE &= ~0x02;
@@ -2091,7 +2131,11 @@ void Power_Off() {
   setValve(VALVE_BOIL_RET, VALVE_OPEN);
   digitalWrite(VENT_FAN, LOW);
   digitalWrite(POWER_FAN, LOW);
+#if BREWIE_HARDWARE_B20
+  B20_VALVE_POWER_PORT &= (uint8_t)~_BV(B20_VALVE_POWER_BIT);
+#else
   digitalWrite(PWR_EN_SERVO, LOW);
+#endif
   // PH7 is reserved for the B20 HX711 clock.
   digitalWrite(PWR_EN_ARM, LOW);
   digitalWrite(PWR_EN_5V, LOW);

--- a/ReBrewie/ReBrewie.ino
+++ b/ReBrewie/ReBrewie.ino
@@ -27,6 +27,13 @@
 #define BREWIE_AUTO_POWER_ON 0
 #endif
 
+// Establish a known hydraulic state whenever the AVR boots.  This is kept
+// separate from BREWIE_AUTO_POWER_ON so valve homing does not enable the ARM
+// rail, start sensor/control processing, or exercise the AC/E210 power path.
+#ifndef BREWIE_CLOSE_VALVES_ON_BOOT
+#define BREWIE_CLOSE_VALVES_ON_BOOT 1
+#endif
+
 // Global Configurations
 uint8_t spargePumpSpeed = 100;      // Reduce sparging pumping speed
 
@@ -2031,6 +2038,10 @@ void Initialize_2560() {
   //PORTJ = 0;
   DDRE |= 0x02;
   PORTE &= ~0x02;
+
+#if BREWIE_CLOSE_VALVES_ON_BOOT
+  Close_All_Valves();
+#endif
 
 #if BREWIE_AUTO_POWER_ON
   Power_On();

--- a/ReBrewie/Valves.cpp
+++ b/ReBrewie/Valves.cpp
@@ -1,8 +1,11 @@
 #include "Valves.h"
 
-#ifdef  B20
+#if BREWIE_HARDWARE_B20
+// Physical B20 harness: valve 9 is unused; the logical outlet and cooling
+// assignments are crossed relative to the earlier table: outlet uses PJ4,
+// cooling uses PJ5.
 volatile uint8_t* Valve_Port[10]  = { &PORTA, &PORTA, &PORTJ, &PORTJ, &PORTA, &PORTA, &PORTA, &PORTA, &PORTA, &PORTA };
-uint8_t Valve_Bitmask[10]         = { 0x01,   0x08,   0x02,   0x01,   0x10,   0x20,   0x40,   0x80,   0x02,   0x04 };
+uint8_t Valve_Bitmask[10]         = { 0x01,   0x08,   0x10,   0x20,   0x10,   0x20,   0x40,   0x80,   0x02,   0x04 };
 #else
 volatile uint8_t* Valve_Port[10]  = { &PORTJ, &PORTJ, &PORTJ, &PORTJ, &PORTA, &PORTA, &PORTA, &PORTA, &PORTA, &PORTC };
 uint8_t Valve_Bitmask[10]         = { 0x04,   0x08,   0x20,   0x40,   0x20,   0x08,   0x80,   0x10,   0x40,   0x02 };
@@ -13,7 +16,14 @@ uint8_t valvePWM = 0;
 uint8_t valveCount = 0;
 
 bool setValve(uint8_t valve, uint8_t angle) {
+  // B20 uses PJ2 as the valve-converter enable. B20+ uses its original
+  // Arduino-mapped servo-enable signal.
+#if BREWIE_HARDWARE_B20
+  B20_VALVE_POWER_DDR |= _BV(B20_VALVE_POWER_BIT);
+  B20_VALVE_POWER_PORT |= _BV(B20_VALVE_POWER_BIT);
+#else
   digitalWrite(PWR_EN_SERVO, HIGH);
+#endif
   uint16_t setAngle = 0;
 
   // Use 0 and 1 to mean closed and open, but also allow for custom angles for higher values
@@ -64,7 +74,11 @@ bool setValve(uint8_t valve, uint8_t angle) {
       valveError[valve] = 0;
     }
     valveState[valve] = setAngle;
-    digitalWrite(PWR_EN_SERVO, LOW);
+#if BREWIE_HARDWARE_B20
+  B20_VALVE_POWER_PORT &= (uint8_t)~_BV(B20_VALVE_POWER_BIT);
+#else
+  digitalWrite(PWR_EN_SERVO, LOW);
+#endif
   }
   return valveState[valve] > VALVE_CLOSE_ANGLE;
 }

--- a/ReBrewie/Valves.h
+++ b/ReBrewie/Valves.h
@@ -2,7 +2,7 @@
 #define Valves_h
 
 #include <Arduino.h>
-#include "B20Plus.h"
+#include "HardwareConfig.h"
 // Valves
 #define VALVE_MASH_IN       0
 #define VALVE_BOIL_RET      1


### PR DESCRIPTION
We added some debug options too.
It's now fully tested on the old B20 with original Linux and the 4.1.0beta Brewie Application. 
When you build it for B20 it should replace the original Control.ino.brewie1.hex firmware. 
Fan control from chassis temp finally working, pump current is correct now.
The B20+ code should not be changed or touched at all. See doc as well.